### PR TITLE
Fix out-of-bounds sample batches in qc plots

### DIFF
--- a/R/qualityControl.R
+++ b/R/qualityControl.R
@@ -413,10 +413,11 @@ add.qc.barplots<-function(report, object, sample.batch.size=50){
 
   plot.names<-NULL
 
-  if(nsamp %% sample.batch.size==1){
-	  sample.batch.size<-sample.batch.size-5
+  if(nsamp %% sample.batch.size == 0){
+	  portion.starts<-0:(nsamp %/% sample.batch.size - 1)*sample.batch.size+1
+  }else if (nsamp %% sample.batch.size != 0){
+	  portion.starts<-0:(nsamp %/% sample.batch.size)*sample.batch.size+1
   }
-  portion.starts<-0:(nsamp %/% sample.batch.size)*sample.batch.size+1
   portion.ends<-portion.starts+sample.batch.size-1
   portion.ends[length(portion.ends)]<-nsamp
   portions<-paste(portion.starts, portion.ends, sep="-")
@@ -483,10 +484,11 @@ add.negative.control.boxplot<-function(report, object, sample.batch.size=50){
 #   sn<-list(tolower(ctypes))
 #   names(sn[[1]])<-gsub(" ", ".", ctypes)
 	nsamp<-length(samples(object))
-	if(nsamp %% sample.batch.size==1){
-		sample.batch.size<-sample.batch.size-5
+	if(nsamp %% sample.batch.size == 0){
+ 	 portion.starts<-0:(nsamp %/% sample.batch.size - 1)*sample.batch.size+1
+	}else if (nsamp %% sample.batch.size != 0){
+  	portion.starts<-0:(nsamp %/% sample.batch.size)*sample.batch.size+1
 	}
-	portion.starts<-0:(nsamp %/% sample.batch.size)*sample.batch.size+1
 	portion.ends<-portion.starts+sample.batch.size-1
 	portion.ends[length(portion.ends)]<-nsamp
 	portions<-paste(portion.starts, portion.ends, sep="-")


### PR DESCRIPTION
**Issue Reference**
Closes #61
 
**Summary of Changes**
This PR fixes an issue where add.qc.barplots() and add.negative.control.boxplot() caused out-of-bounds errors when processing sample batches.
 
**Steps to Reproduce (Before Fix)**
1.	Run rnb.run.qc() with rnb.options(qc.sample.batch.size = 50) and a dataset with sample size divisible by 50.
2.	Observe the error: 
        Error in qc(rnb.set)$Cy3[, sample.subset, drop = FALSE] : subscript out of bounds
 
**Fix Implemented**
Updated the indexing logic to ensure sample batches remain within valid bounds.
