### PR TITLE
added enable-disable option for nv-probe tables

### DIFF
--- a/R/differentialMethylation.R
+++ b/R/differentialMethylation.R
@@ -2054,7 +2054,7 @@ rnb.section.diffMeth.site <- function(rnbSet,diffmeth,report,gzTable=FALSE){
 		sectionText <- paste(sectionText,"<li>",txt,"</li>\n",sep="")
 	}
 	## Save table of only the nv-probes in EPICv2
-	if (rnbSet@target == "probesEPICv2" & any(grepl("^nv", dmt$cgid))) {
+	if (rnbSet@target == "probesEPICv2" & rnb.getOption("nv.probe.tables") & any(grepl("^nv", dmt$cgid))) { 
 		logger.info("Saving table(s) containing only nv-probes")
 		sectionText <- paste(sectionText,"</ul>",sep="")
 		rnb.add.paragraph(report, sectionText)
@@ -2064,7 +2064,7 @@ rnb.section.diffMeth.site <- function(rnbSet,diffmeth,report,gzTable=FALSE){
 
 		logger.info("Enriching nv-probes comparison table with HGNC symbols. see: GeneSymbol column in the finished table.")
 		rnb.require("biomaRt")
-		mart <- useMart("ENSEMBL_MART_ENSEMBL", dataset = "hsapiens_gene_ensembl",host="https://feb2023.archive.ensembl.org")
+		mart <- useMart("ENSEMBL_MART_ENSEMBL", dataset = "hsapiens_gene_ensembl",host="https://sep2025.archive.ensembl.org")
 
 		refText <- c("Kaur, D., Lee, S. M., Goldberg, D., Spix, N. J., Hinoue, T., Li, H.-T., Dwaraka, V. B., Smith, R., ",
 					 "Shen, H., Liang, G., Renke, N., Laird, P. W., & Zhou, W. (2023). Comprehensive evaluation of the Infinium human ",

--- a/R/main.R
+++ b/R/main.R
@@ -1527,7 +1527,7 @@ rnb.run.exploratory <- function(rnb.set, dir.reports,
 		txt <- c("Overview of nv probes and sample comparison based on them cannot be performed ",
 			"because the dataset does not contain nv probes.")
 		report <- rnb.add.section(report, section.title, txt)
-	} else if (rnb.set@target == "probesEPICv2" & (rnb.getOption("nv.heatmap") | rnb.getOption("nv.beta.distribution"))) {
+	} else if (rnb.set@target == "probesEPICv2" & rnb.getOption("nv.probe.tables") & (rnb.getOption("nv.heatmap") | rnb.getOption("nv.beta.distribution"))) {
 		refText <- c("Kaur, D., Lee, S. M., Goldberg, D., Spix, N. J., Hinoue, T., Li, H.-T., Dwaraka, V. B., Smith, R., ",
 					 "Shen, H., Liang, G., Renke, N., Laird, P. W., & Zhou, W. (2023). Comprehensive evaluation of the Infinium human ",
 					 "MethylationEPIC v2 BeadChip. <i>Epigenetics Communications</i>, <b>3</b>(1), 6.")
@@ -1540,7 +1540,7 @@ rnb.run.exploratory <- function(rnb.set, dir.reports,
 		data.dir.rel <- rnb.get.directory(report, "data")
 		nv.probe.ids <- strsplit(rownames(nv.probes), split = "-")
 		rnb.require("biomaRt")
-		ensembl <- useMart("ENSEMBL_MART_ENSEMBL", dataset = "hsapiens_gene_ensembl",host="https://feb2023.archive.ensembl.org")
+		ensembl <- useMart("ENSEMBL_MART_ENSEMBL", dataset = "hsapiens_gene_ensembl",host="https://sep2025.archive.ensembl.org")
 		chromosomes <- sapply(nv.probe.ids, function(x) x[[3]])
 		start <- sapply(nv.probe.ids, function(x) x[[4]])
 		end <- sapply(nv.probe.ids, function(x) x[[5]])

--- a/R/options.R
+++ b/R/options.R
@@ -893,6 +893,8 @@ rnb.is.option <- function(txt) {
 #'        Flag indicating whether disked dumped big matrices (see \code{disk.dump.big.matrices} option) should actively
 #'        be deleted when RnBSets are modified. You should switch it to \code{TRUE} when \code{disk.dump.big.matrices}
 #' 		  is \code{TRUE} and the amount of hard drive space is also limited.}
+#' \item{\bold{\code{nv.probe.tables}}\code{ = FALSE}}{
+#'        Flag indicating whether nv-probe tables are generated. If \code{TRUE}, tables are generated.}
 #' }
 #'
 #' @examples

--- a/R/profiles.R
+++ b/R/profiles.R
@@ -700,7 +700,7 @@ rnb.get.nv.probes.matrix <- function(dataset, threshold.nas = 1) {
 			rnb.error("Not enough nv probe data available (too many missing values per probe)")
 		}
 		result <- result[-i, , drop = FALSE]
-		rnb.warning(paste(length(i), "probes ignored because their they contain too many NAs"))
+		rnb.warning(paste(length(i), "probes ignored because they contain too many NAs"))
 	}
 	i <- which(apply(is.na(result), 2, mean) > threshold.nas)
 	if (length(i) != 0) {

--- a/inst/extdata/options.txt
+++ b/inst/extdata/options.txt
@@ -129,3 +129,4 @@ disk.dump.bigff	logical	no	no		TRUE
 disk.dump.bigff.finalizer	character	no	no	(delete,close)	delete
 enforce.memory.management	logical	no	no		FALSE
 enforce.destroy.disk.dumps	logical	no	no		FALSE
+nv.probe.tables	logical	no	no		FALSE


### PR DESCRIPTION
Problem: 
Recent RnBeads differential analysis of EPICv2 arrays encountered http 500 request error when querying nv-probe annotations with useMart(). The 'host' argument of the function is an ensembl archive repository ('feb2023...') which is not responding. This causes rnb.run.differentials() to stop before finalizing the process.
Fix: 
added logical option nv.probe.tables to disable the generation of nv-probe tables. Also changed the host to the latest archive ('sep2025')